### PR TITLE
Fix minor markdownlint warnings

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,5 @@
-## Code of Conduct
+# Code of Conduct
+
 This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
 For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
 opensource-codeofconduct@amazon.com with any additional questions or comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 ## Joining Alpha program
+
 This program is currently in alpha stage and is limited access.  If you are interested in joining please reach out to aws-ia-eng@amazon.com
 
 # Contributing Guidelines
@@ -22,8 +23,8 @@ reported the issue. Please try to include as much information as you can. Detail
 * Any modifications you've made relevant to the bug
 * Anything unusual about your environment or deployment
 
-
 ## Contributing via Pull Requests
+
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
 1. You are working against the latest source on the *master* branch.


### PR DESCRIPTION
Fix markdownlint warnings

./CONTRIBUTING.md
* MD012: Multiple consecutive blank lines
* MD022: Headings should be surrounded by blank lines
* Ignoring intentional MD041

./CODE_OF_CONDUCT.md
* MD022: Headings should be surrounded by blank lines
* MD041: First line in a file should be a top-level heading
